### PR TITLE
Rms/makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+ifndef ETHEREUM_MAINNET_ENDPOINT
+    ifneq (,$(wildcard ./.env))
+        include .env
+        export
+    else
+        export ETHEREUM_MAINNET_ENDPOINT=https://eth.llamarpc.com
+    endif
+endif
+
+EXAMPLES=$(wildcard examples/*.rs)
+EXAMPLES_BIN=$(patsubst examples/%.rs,%,$(EXAMPLES))
+
+define generate_example_target
+$(1):
+	cargo run --example $(1)
+endef
+
+$(foreach example,$(EXAMPLES_BIN),$(eval $(call generate_example_target,$(example))))
+
+.PHONY: all
+all: $(EXAMPLES_BIN)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Sync pairs simulate swaps, and interact with constant function market makers on 
 
 ## Running Examples
 
-To run any of the example with make `make <example_name>` eg:
+Run any of the examples with make `make <example_name>` eg:
 ```bash
 make create-new-pool
 ```

--- a/README.md
+++ b/README.md
@@ -21,5 +21,13 @@ Sync pairs simulate swaps, and interact with constant function market makers on 
 
 ## Running Examples
 
-To run any of the examples, first set a local environment variable called `ETHEREUM_MAINNET_ENDPOINT`. Then you can simply run `cargo run --example <example_name>`.
+To run any of the example with make `make <example_name>` eg:
+```bash
+make create-new-pool
+```
 
+You can also export your RPC endpoint.
+```bash
+export ETHEREUM_MAINNET_ENDPOINT=https://eth.llamarpc.com
+cargo run --example <example_name>
+```


### PR DESCRIPTION
Add a `Makefile` to be able to run any of the files inside the examples directory. It will list the dir and create a command with a default RPC ready to use. You can also create a `.env` to put your RPC then the default one will not be used.